### PR TITLE
Fix crash in iOs Safari (tested on iOs 8.4.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bower_components
 node_modules
+.idea/
 *.log
 .DS_Store
 bundle.js

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "gl-mat4": "^1.1.3"
+    "gl-mat4": "git+https://github.com/stackgl/gl-mat4.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "gl-mat4": "git+https://github.com/stackgl/gl-mat4.git"
+    "gl-mat4": "^1.1.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "css-transform-to-mat4",
+  "version": "1.0.2",
+  "author": {
+      "name": "Mikko Haapoja",
+      "email": "me@mikkoh.com",
+      "url": "https://github.com/mikkoh"
+  },
+  "description": "Will take a string which is a css transform value (2d or 3d) and return a mat4 or 3d transformation matrix from the string.",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "gl-mat4": "^1.1.3"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function cssTransformToMatrix(value) {
         //   e, f, 0, 1)
 
 
-        value = value.split(',').map(Number.parseFloat);
+        value = value.split(',').map(parseFloat);
         matrix = [
           value[ 0 ], value[ 1 ], 0, 0,
           value[ 2 ], value[ 3 ], 0, 0,
@@ -46,13 +46,13 @@ module.exports = function cssTransformToMatrix(value) {
       break;
 
       case 'matrix3d':
-        matrix = value.split(',').map(Number.parseFloat);
+        matrix = value.split(',').map(parseFloat);
       break;
 
       case 'translate':
       case 'translate3d':
         matrix = createMatrix();
-        value = value.split(',').map(Number.parseFloat);
+        value = value.split(',').map(parseFloat);
 
         if(value.length === 2) {
           value.push(0);
@@ -63,19 +63,19 @@ module.exports = function cssTransformToMatrix(value) {
 
       case 'translateX':
         matrix = createMatrix();
-        value = [ Number.parseFloat(value), 0, 0 ];
+        value = [ parseFloat(value), 0, 0 ];
         mat4Translate(matrix, matrix, value);
       break;
 
       case 'translateY':
         matrix = createMatrix();
-        value = [ 0, Number.parseFloat(value), 0 ];
+        value = [ 0, parseFloat(value), 0 ];
         mat4Translate(matrix, matrix, value);
       break;
 
       case 'translateZ':
         matrix = createMatrix();
-        value = [ 0, 0, Number.parseFloat(value) ];
+        value = [ 0, 0, parseFloat(value) ];
         mat4Translate(matrix, matrix, value);
       break;
 
@@ -89,7 +89,7 @@ module.exports = function cssTransformToMatrix(value) {
       case 'scale':
       case 'scale3d':
         matrix = createMatrix();
-        value = value.split(',').map(Number.parseFloat);
+        value = value.split(',').map(parseFloat);
 
         if(value.length === 2) {
           value.push(1);  
@@ -100,17 +100,17 @@ module.exports = function cssTransformToMatrix(value) {
 
       case 'scaleX':
         matrix = createMatrix();
-        mat4Scale(matrix, matrix, [Number.parseFloat(value), 1, 1]);
+        mat4Scale(matrix, matrix, [parseFloat(value), 1, 1]);
       break;
 
       case 'scaleY':
         matrix = createMatrix();
-        mat4Scale(matrix, matrix, [1, Number.parseFloat(value), 1]);
+        mat4Scale(matrix, matrix, [1, parseFloat(value), 1]);
       break;
 
       case 'scaleZ':
         matrix = createMatrix();
-        mat4Scale(matrix, matrix, [1, 1, Number.parseFloat(value)]);
+        mat4Scale(matrix, matrix, [1, 1, parseFloat(value)]);
       break;
 
       case 'rotateX':
@@ -128,14 +128,14 @@ module.exports = function cssTransformToMatrix(value) {
       case 'rotate3d':
         matrix = createMatrix();
         value = value.split(',');
-        mat4Rotate(matrix, matrix, getRadian(value[3]), value.slice(0, 3).map(Number.parseFloat));
+        mat4Rotate(matrix, matrix, getRadian(value[3]), value.slice(0, 3).map(parseFloat));
       break;
 
       case 'perspective':
         // The matrix is computed by starting with an identity matrix and replacing the value at row 3, 
         // column 4 with the value -1/depth. The value for depth must be greater than zero, otherwise 
         // the function is invalid.
-        value = Number.parseFloat(value);
+        value = parseFloat(value);
 
         matrix = [
           1, 0, 0, 0,

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-var mat4RotateX = require('gl-mat4/rotateX');
-var mat4RotateY = require('gl-mat4/rotateY');
-var mat4RotateZ = require('gl-mat4/rotateZ');
-var mat4Rotate = require('gl-mat4/rotate');
-var mat4Scale = require('gl-mat4/scale');
-var mat4Translate = require('gl-mat4/translate');
-var mat4Multiply = require('gl-mat4/multiply');
+var mat4RotateX = require('gl-mat4').rotateX;
+var mat4RotateY = require('gl-mat4').rotateY;
+var mat4RotateZ = require('gl-mat4').rotateZ;
+var mat4Rotate = require('gl-mat4').rotate;
+var mat4Scale = require('gl-mat4').scale;
+var mat4Translate = require('gl-mat4').translate;
+var mat4Multiply = require('gl-mat4').multiply;
 
 // Spec was used for reference http://www.w3.org/TR/2009/WD-css3-3d-transforms-20090320/
 module.exports = function cssTransformToMatrix(value) {


### PR DESCRIPTION
In mobile Safari Number has no parseFloat method
